### PR TITLE
ci: add workflow_dispatch and schedule once a week

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,8 @@ on:
       - main
   pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 3'
 
 jobs:
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
 

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - main
-
   pull_request:
+  workflow_dispatch:
 
 jobs:
   python-run:

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -6,6 +6,8 @@ on:
       - main
   pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 3'
 
 jobs:
   python-run:


### PR DESCRIPTION
Since CI is only triggered when pushing to either the main branch or some PR, it can be unused for long periods. For instance, last time main CI run here was 3 months ago: https://github.com/antmicro/raviewer/actions?query=branch%3Amain.
This PR adds the workflow_dispatch event to allow triggering runs without pushing code changes.
Moreover, a weekly run is scheduled, to avoid long periods without CI testing.